### PR TITLE
Add Placement Assist for Cogs on TieredShaftBlock

### DIFF
--- a/src/main/java/electrolyte/greate/content/kinetics/simpleRelays/TieredShaftBlock.java
+++ b/src/main/java/electrolyte/greate/content/kinetics/simpleRelays/TieredShaftBlock.java
@@ -83,7 +83,7 @@ public class TieredShaftBlock extends ShaftBlock implements ITieredBlock, ITiere
         if (resultGirderEncase.consumesAction()) return resultGirderEncase;
 
         IPlacementHelper helper = PlacementHelpers.get(placementHelperId);
-        if (Block.byItem(heldItem.getItem()) == pState.getBlock())
+        if (helper.matchesItem(heldItem))
             return helper.getOffset(pPlayer, pLevel, pState, pPos, pHit)
                     .placeInWorld(pLevel, (BlockItem) heldItem.getItem(), pPlayer, pHand, pHit);
 


### PR DESCRIPTION
I am unsure if this is only an issue that I am having, but attempting to place cogs while looking at a shaft doesn't behave the same way as Creates' cogs/shafts. 

Attempting to place a cog on a shaft should either place it at one of the ends of the shaft (where the preview ghosts appears), not directly on the face of the shaft you're looking at.

I've updated the code to the way create does it with their shafts.
Before it would only work shaft on shaft, now it should work cog on shaft as well.