### PR TITLE
Make crushing recipe IDs unique for EMI

### DIFF
--- a/src/main/java/electrolyte/greate/compat/jei/category/TieredCrushingCategory.java
+++ b/src/main/java/electrolyte/greate/compat/jei/category/TieredCrushingCategory.java
@@ -7,6 +7,7 @@ import com.simibubi.create.foundation.gui.AllGuiTextures;
 import electrolyte.greate.Greate;
 import electrolyte.greate.compat.jei.category.animations.TieredAnimatedCrushingWheels;
 import electrolyte.greate.content.kinetics.crusher.TieredAbstractCrushingRecipe;
+import electrolyte.greate.content.kinetics.millstone.TieredMillingRecipe;
 import electrolyte.greate.registry.CrushingWheels;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.builder.IRecipeSlotBuilder;
@@ -17,6 +18,7 @@ import net.createmod.catnip.lang.Lang;
 import net.createmod.catnip.layout.LayoutHelper;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.resources.ResourceLocation;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.ArrayList;
@@ -45,6 +47,16 @@ public class TieredCrushingCategory extends GreateRecipeCategory<TieredAbstractC
                     .addItemStack(entry.output().getStack());
             baseBuilder.addRichTooltipCallback(CreateRecipeCategory.addStochasticTooltip(entry.output));
         });
+    }
+
+    @Override
+    public ResourceLocation getRegistryName(TieredAbstractCrushingRecipe recipe) {
+        ResourceLocation id = super.getRegistryName(recipe);
+        if (id != null && recipe instanceof TieredMillingRecipe) {
+            return ResourceLocation.fromNamespaceAndPath(id.getNamespace(),
+                    "crushing" + id.getPath().substring("milling".length()));
+        }
+        return id;
     }
 
     private List<LayoutEntry> layoutOutput(ProcessingRecipe<?> recipe) {


### PR DESCRIPTION
When Greate adds all milling recipes to the crushing recipes category, it uses the same recipe IDs. This is fine for JEI, where recipe IDs are scoped to their category.

However, for EMI, recipe IDs are checked globally. So when JEI recipes are imported into EMI via JEMI or TMRV everything does still work, but EMI will record several thousand errors about duplicate IDs.

<img width="1632" height="134" alt="image" src="https://github.com/user-attachments/assets/c1c9263c-9978-47e9-966a-8576a0f1eafd" />

This PR fixes this by renaming the crushing recipes that get added from `greate:milling/` to `greate:crushing/`