### PR TITLE
Make blockcutting recipes unique, and collapse DifferenceIngredient recipes

### DIFF
--- a/src/main/java/electrolyte/greate/compat/jei/category/TieredBlockCuttingCategory.java
+++ b/src/main/java/electrolyte/greate/compat/jei/category/TieredBlockCuttingCategory.java
@@ -17,7 +17,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.StonecutterRecipe;
-import electrolyte.greate.mixin.DifferenceIngredientAccessor;
+import electrolyte.greate.mixin.MixinDifferenceIngredientAccessor;
 import net.minecraftforge.common.crafting.DifferenceIngredient;
 import net.minecraftforge.registries.ForgeRegistries;
 import org.jetbrains.annotations.Nullable;
@@ -145,7 +145,7 @@ public class TieredBlockCuttingCategory extends GreateRecipeCategory<TieredConde
      */
     private static @Nullable TagKey<Item> getTag(Ingredient ingredient) {
         if (ingredient instanceof DifferenceIngredient diff)
-            return getTag(((DifferenceIngredientAccessor) diff).getBase());
+            return getTag(((MixinDifferenceIngredientAccessor) diff).getBase());
         Ingredient.Value[] values = ingredient.values;
         if (values.length == 1 && values[0] instanceof Ingredient.TagValue tagValue)
             return tagValue.tag;

--- a/src/main/java/electrolyte/greate/compat/jei/category/TieredBlockCuttingCategory.java
+++ b/src/main/java/electrolyte/greate/compat/jei/category/TieredBlockCuttingCategory.java
@@ -11,10 +11,16 @@ import mezz.jei.api.recipe.IFocusGroup;
 import mezz.jei.api.recipe.RecipeIngredientRole;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.StonecutterRecipe;
+import electrolyte.greate.mixin.DifferenceIngredientAccessor;
+import net.minecraftforge.common.crafting.DifferenceIngredient;
+import net.minecraftforge.registries.ForgeRegistries;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -57,8 +63,8 @@ public class TieredBlockCuttingCategory extends GreateRecipeCategory<TieredConde
 
         List<ItemStack> outputs = new ArrayList<>();
 
-        public TieredCondensedBlockCuttingRecipe(Ingredient ingredient) {
-            super(new ResourceLocation(""), "", ingredient, ItemStack.EMPTY);
+        public TieredCondensedBlockCuttingRecipe(ResourceLocation id, Ingredient ingredient) {
+            super(id, "", ingredient, ItemStack.EMPTY);
         }
 
         public void addOutput(ItemStack stack) {
@@ -98,16 +104,56 @@ public class TieredBlockCuttingCategory extends GreateRecipeCategory<TieredConde
         Recipes: for(Recipe<?> recipe : stoneCuttingRecipes) {
             Ingredient ingredient = recipe.getIngredients().get(0);
             for(TieredCondensedBlockCuttingRecipe tieredCondensedRecipe : condensedRecipes) {
-                if(ItemHelper.matchIngredients(ingredient, tieredCondensedRecipe.getIngredients().get(0))) {
+                if(matchIngredients(ingredient, tieredCondensedRecipe.getIngredients().get(0))) {
                     tieredCondensedRecipe.addOutput(getResultItem(recipe));
                     continue Recipes;
                 }
             }
 
-            TieredCondensedBlockCuttingRecipe tcbcr = new TieredCondensedBlockCuttingRecipe(ingredient);
+            String tagName = getTagName(ingredient);
+            String idPath;
+            if (tagName != null) {
+                idPath = "block_cutting/" + tagName.replace(':', '/');
+            } else {
+                ResourceLocation inputId = ForgeRegistries.ITEMS.getKey(ingredient.getItems()[0].getItem());
+                idPath = "block_cutting/" + inputId.getNamespace() + "/" + inputId.getPath();
+            }
+
+            ResourceLocation recipeId = ResourceLocation.fromNamespaceAndPath("greate", idPath);
+            TieredCondensedBlockCuttingRecipe tcbcr = new TieredCondensedBlockCuttingRecipe(recipeId, ingredient);
             tcbcr.addOutput(getResultItem(recipe));
             condensedRecipes.add(tcbcr);
         }
         return condensedRecipes;
+    }
+
+    /**
+     * Condense recipes based on input items, input tags, or DifferenceIngredient base tags.
+     */
+    private static boolean matchIngredients(Ingredient a, Ingredient b) {
+        if (ItemHelper.matchIngredients(a, b)) return true;
+        var tagA = getTag(a);
+        var tagB = getTag(b);
+        if (tagA != null && tagB != null)
+            return tagA.equals(tagB);
+        return false;
+    }
+
+    /**
+     * Get tag for an Ingredient.
+     * For DifferenceIngredient, get the base tag.
+     */
+    private static @Nullable TagKey<Item> getTag(Ingredient ingredient) {
+        if (ingredient instanceof DifferenceIngredient diff)
+            return getTag(((DifferenceIngredientAccessor) diff).getBase());
+        Ingredient.Value[] values = ingredient.values;
+        if (values.length == 1 && values[0] instanceof Ingredient.TagValue tagValue)
+            return tagValue.tag;
+        return null;
+    }
+
+    private static @Nullable String getTagName(Ingredient ingredient) {
+        var tag = getTag(ingredient);
+        return tag != null ? tag.location().toString() : null;
     }
 }

--- a/src/main/java/electrolyte/greate/mixin/MixinDifferenceIngredientAccessor.java
+++ b/src/main/java/electrolyte/greate/mixin/MixinDifferenceIngredientAccessor.java
@@ -1,0 +1,13 @@
+package electrolyte.greate.mixin;
+
+import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraftforge.common.crafting.DifferenceIngredient;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(DifferenceIngredient.class)
+public interface MixinDifferenceIngredientAccessor {
+
+    @Accessor(value = "base", remap = false)
+    Ingredient getBase();
+}

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -2,3 +2,6 @@ public net.minecraft.world.item.crafting.RecipeManager f_44007_ # recipes
 public net.minecraft.server.network.ServerGamePacketListenerImpl f_9737_ # aboveGroundTickCount
 public net.minecraft.server.ReloadableServerResources f_206849_ # tagManager
 public net.minecraft.client.renderer.RenderStateShard f_110133_ #name
+public net.minecraft.world.item.crafting.Ingredient f_43902_ # values
+public net.minecraft.world.item.crafting.Ingredient$TagValue
+public net.minecraft.world.item.crafting.Ingredient$TagValue f_43959_ # tag

--- a/src/main/resources/greate.mixin.json
+++ b/src/main/resources/greate.mixin.json
@@ -4,6 +4,7 @@
   "minVersion": "0.8",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
+    "DifferenceIngredientAccessor",
     "MixinAirCurrent",
     "MixinAirCurrentInvoker",
     "MixinAllArmInteractionPointTypes$BeltType",

--- a/src/main/resources/greate.mixin.json
+++ b/src/main/resources/greate.mixin.json
@@ -4,7 +4,6 @@
   "minVersion": "0.8",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
-    "DifferenceIngredientAccessor",
     "MixinAirCurrent",
     "MixinAirCurrentInvoker",
     "MixinAllArmInteractionPointTypes$BeltType",
@@ -21,6 +20,7 @@
     "MixinCrushingWheelControllerBlockEntity",
     "MixinCStress",
     "MixinDeployerBlockEntity",
+    "MixinDifferenceIngredientAccessor",
     "MixinFluidPropagator",
     "MixinGirderBlock",
     "MixinGirderEncasedShaftBlock",


### PR DESCRIPTION
This PR does two things:

1:
Right now all blockcutting recipes in JEI/EMI get the same recipe ID. While this works okay in gameplay, it creates an EMI error and hides legitimate issues.
<img width="967" height="38" alt="image" src="https://github.com/user-attachments/assets/943f1308-5bb4-468d-b8c9-aa1cdebab9cc" />

This PR gives blockcutting recipes a unique ID based on the input item or tag

2:
For TFG we use a lot of DifferenceIngredients for stonecutting recipes.

A DifferenceIngredient is an input ingredient based on a tag minus specific blocks. You can use them to easily allow stonecutting from any block in the tag to any other block except itself.

The problem is that for greate's blockcutting, it creates a lot of redundant recipes because each input list is slightly different, missing one block or another, where really all we want to show is that you can cut from any block in the tag to any other.

<img width="356" height="957" alt="image" src="https://github.com/user-attachments/assets/d377acac-7cf7-4e20-84c5-2ff91484a34f" />

^These can be condensed into a single recipe

This PR condenses recipes that have a DifferenceIngredient input based on the base tag that the DifferenceIngredient is based on. 

This cuts down the amount of blockcutting recipes in EMI by about half and makes them easier to read.

---

This PR only affects the JEI/EMI view, it does not affect any actual gameplay recipes